### PR TITLE
Github Actions set to pull_request is not enough for our needs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,10 @@
 name: Checks
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/sim-sanity-test.yml
+++ b/.github/workflows/sim-sanity-test.yml
@@ -1,6 +1,10 @@
 name: Simulator Sanity Test
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   sim-startup:


### PR DESCRIPTION
Setting to pull_request should have been enough but that means that the resulting merge to main doesn't get an action run.  Going more granular so that actions run both on pull_requests and on merges to main.