### PR TITLE
Optimize Swerve Module rotation

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -147,6 +147,9 @@ kMaxWheelAngularVelocity = kMaxMotorAngularVelocity / kDriveGearingRatio
 kMaxWheelLinearVelocity = kWheelDistancePerRadian * kMaxWheelAngularVelocity
 """meters / second"""
 
+kMinWheelLinearVelocity = 0.002
+"""meters / second"""
+
 kMaxSteerAngularVelocity = kMaxMotorAngularVelocity / kSteerGearingRatio
 """radians / second"""
 

--- a/subsystems/drivesubsystem.py
+++ b/subsystems/drivesubsystem.py
@@ -55,7 +55,10 @@ class SwerveModule:
         optimizedState = SwerveModuleState.optimize(state, self.getSwerveAngle())
         # optimizedState = state
         self.setWheelLinearVelocityTarget(optimizedState.speed)
-        self.setSwerveAngleTarget(optimizedState.angle)
+        if (
+            abs(optimizedState.speed) >= constants.kMinWheelLinearVelocity
+        ):  # prevent unneccisary movement for what would otherwise not move the robot
+            self.setSwerveAngleTarget(optimizedState.angle)
 
 
 # pylint: disable=abstract-method

--- a/subsystems/drivesubsystem.py
+++ b/subsystems/drivesubsystem.py
@@ -1,5 +1,6 @@
 from enum import Enum, auto
 
+from math import tau, floor
 from commands2 import SubsystemBase
 from wpilib import Encoder, PWMVictorSPX, RobotBase, SmartDashboard, Timer
 from ctre import (
@@ -18,8 +19,8 @@ from wpimath.kinematics import (
     SwerveDrive4Kinematics,
     SwerveDrive4Odometry,
 )
-from enum import Enum, auto
-from math import tau, floor
+
+
 import constants
 from util import convenientmath
 


### PR DESCRIPTION
this does twofold

1. ensures that the most optimal path is taken for the wheels, accounting for potential rotation boundaries
2. in the event the wheels are not moving enough to matter (as now used with kMinWheelLinearVelocity) the wheels of that one module will not rotate, this prevents "snappish" resetting behavior when not required