### PR TITLE
search mode for when target is not in view

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -436,3 +436,5 @@ kCameraSimServoObjectName = "Camera Servo"
 kCameraServoPGain = 0.15
 kCameraServoIGain = 0.0
 kCameraServoDGain = 0.0
+
+kCameraSearchModeSpeed = 5.0

--- a/subsystems/visionsubsystem.py
+++ b/subsystems/visionsubsystem.py
@@ -1,4 +1,5 @@
 import typing
+from math import sin
 
 from commands2 import SubsystemBase
 from networktables import NetworkTables
@@ -194,6 +195,14 @@ class LimelightTrackingModule(TrackingModule):
         else:
             self.targetAngle = None
 
+            guessRotationAmount = sin(
+                Timer.getMatchTime() * constants.kCameraSearchModeSpeed
+            )
+
+            self.setServoAngle(
+                Rotation2d(guessRotationAmount * constants.kCameraServoMaxAngle)
+            )
+
         TrackingModule.update(self)
 
     def reset(self) -> None:
@@ -249,10 +258,10 @@ class VisionSubsystem(SubsystemBase):
             )
             SmartDashboard.putBoolean(constants.kTargetPoseArrayKeys.validKey, True)
 
-            SmartDashboard.putNumber(
-                constants.kCameraServoRotationNumberKey,
-                self.trackingModule.getServoAngle().degrees(),
-            )
+        SmartDashboard.putNumber(
+            constants.kCameraServoRotationNumberKey,
+            self.trackingModule.getServoAngle().degrees(),
+        )
 
         if self.printTimer.hasPeriodPassed(constants.kPrintPeriod):
             print(


### PR DESCRIPTION
limelight currently just stops in the event that there is no target found, this attempts to simple refind the target by moving in a simple sine wave