### PR TITLE
Add check for RobotPy updates

### DIFF
--- a/.github/workflows/check-robotpy-for-updates.yml
+++ b/.github/workflows/check-robotpy-for-updates.yml
@@ -1,0 +1,24 @@
+name: Check For RobotPy Updates
+
+on:
+  schedule:
+    # In UTC this is 7am EST
+    - cron: "* 12 * * *"
+
+jobs:
+  check-robot-py:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-deps -r requirements.txt
+          ./scripts/check-for-pip-updates.sh

--- a/README.md
+++ b/README.md
@@ -142,25 +142,16 @@ py -3 -m venv ./.venv
      ```bash
      python robot.py sim
      ```
-     python -m robotpy_installer install-python
-
-   ```
-
-   ```
-
-1. **Upload robotpy modules to roboRIO**
-   (must be connected to roboRIO)
-   ```bash
-   python -m robotpy_installer install robotpy
-   ```
-   (examples: `robotpy`, `robotpy[ctre,navx]`, `robotpy[all]`) (see: [robotpy on pypi](https://pypi.org/project/robotpy/))
-1. **Deploy robotpy program**
-   - To robot
-     (must be connected to roboRIO)
-     ```bash
-     python robot.py deploy
-     ```
-   - To simulator
-     ```bash
-     python robot.py sim
-     ```
+#### Update PIP requirements
+If there are RobotPy updates we want to upgrade our requirements.txt file to match after verifying it works.
+1. **Install latest version**
+    ```bash
+    pip install --upgrade -r requirements-upgrade.txt
+    ```
+1. **Verify on simulator and/or hardware**
+1. **Freeze versions**
+    ```bash
+    pip freeze -r requirements.txt > requirements-new.txt
+    Copy robotpy section from requirements-new.txt to requirements.txt
+    ```
+1. **Open PR with Updates**

--- a/requirements-upgrade.txt
+++ b/requirements-upgrade.txt
@@ -1,0 +1,15 @@
+# RobotPy packages without pinning, solely to be used for upgrading the main requirements.txt file.
+pyfrc
+pynetconsole
+pynetworktables
+pyntcore
+robotpy-commands-v2
+robotpy-ctre
+robotpy-hal
+robotpy-halsim-gui
+robotpy-installer
+robotpy-navx
+robotpy-wpimath
+robotpy-wpiutil
+wpilib
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,15 +31,15 @@ wrapt
 # updates we don't break the world until we have a chance to test/update.
 pyfrc==2022.0.0
 pynetconsole==2.0.2
-pynetworktables==2021.0.0.0
-pyntcore==2022.2.1.0
+pynetworktables==2021.0.0
+pyntcore==2022.2.1.1
 robotpy-commands-v2==2022.2.1.0
-robotpy-ctre==2022.0.3
-robotpy-hal==2022.2.1.0
+robotpy-ctre==2022.0.4
+robotpy-hal==2022.2.1.1
 robotpy-halsim-gui==2022.2.1.0
-robotpy-installer==2022.0.0
+robotpy-installer==2022.0.1
 robotpy-navx==2022.0.0
-robotpy-wpimath==2022.2.1.1
-robotpy-wpiutil==2022.2.1.0
-wpilib==2022.2.1.1
+robotpy-wpimath==2022.2.1.2
+robotpy-wpiutil==2022.2.1.1
+wpilib==2022.2.1.3
 

--- a/scripts/check-for-pip-updates.sh
+++ b/scripts/check-for-pip-updates.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+OUTPUT=$(pip list --outdated --exclude=setuptools)
+if [[ ! -z "$OUTPUT" ]]
+then
+    echo "$OUTPUT"
+    exit 1
+else
+    echo "pip packages are up to date"
+fi
+
+exit 0


### PR DESCRIPTION
Add a simple github action so we will get a reminder to update RobotPy when it updates.  It doesn't apply to PR/Push so it doesn't prevent a PR from merging but it will let us know we need to update.

Updated to latest RobotPy rebuild in separate commit