### PR TITLE
accurate setPosition function

### DIFF
--- a/util/helpfulIO.py
+++ b/util/helpfulIO.py
@@ -82,9 +82,9 @@ class Falcon:  # represents either a simulated motor or a real Falcon 500
         if RobotBase.isReal():
             self.motor.set(ControlMode.Position, pos)
         else:
-            positionChange = pos - self.simEncoder
+            positionChange = self.simEncoder - pos
             change = self.pidController.calculate(positionChange)
-            self._setSimMotor(change)
+            self._setSimMotor(change / constants.kTalonEncoderPulsesPerRevolution)
 
     def getPosition(self) -> int:
         """returns the position in encoder ticks"""


### PR DESCRIPTION
the current simulation setPosition does not work as intended, this is the fix to determine proper change

1. change is desired - current, not vice versa
2. movement should take into account that the change is in encoder ticks, not movement of the motor