### PR TITLE
Switch pylint local disable to use disable-next

### DIFF
--- a/commands/drivedistance.py
+++ b/commands/drivedistance.py
@@ -46,7 +46,7 @@ class DriveDistance(CommandBase):
                 0, self.speedFactor, 0, DriveSubsystem.CoordinateMode.RobotRelative
             )
 
-    # pylint: disable=unused-argument
+    # pylint: disable-next=unused-argument
     def end(self, interrupted: bool) -> None:
         self.drive.arcadeDriveWithFactors(
             0, 0, 0, DriveSubsystem.CoordinateMode.RobotRelative

--- a/commands/resetdrive.py
+++ b/commands/resetdrive.py
@@ -16,9 +16,10 @@ class ResetDrive(CommandBase):
     def execute(self) -> None:
         self.drive.resetSwerveModules()
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable-next=unused-argument,no-self-use
     def end(self, interrupted: bool) -> None:
         print("... DONE")
 
+    # pylint: disable-next=unused-argument,no-self-use
     def isFinished(self) -> bool:
         return True

--- a/physics.py
+++ b/physics.py
@@ -214,7 +214,7 @@ class PhysicsEngine:
 
         self.limelightSim = LimelightSim()
 
-    # pylint: disable=unused-argument
+    # pylint: disable-next=unused-argument
     def update_sim(self, now: float, tm_diff: float) -> None:
         """
         Called when the simulation parameters for the program need to be

--- a/robot.py
+++ b/robot.py
@@ -58,7 +58,7 @@ class MentorBot(commands2.TimedCommandRobot):
     def teleopPeriodic(self) -> None:
         """This function is called periodically during operator control"""
 
-    # pylint: disable=no-self-use
+    # pylint: disable-next=no-self-use
     def testInit(self) -> None:
         # Cancels all running commands at the start of test mode
         commands2.CommandScheduler.getInstance().cancelAll()

--- a/subsystems/drivesubsystem.py
+++ b/subsystems/drivesubsystem.py
@@ -86,7 +86,7 @@ class SwerveModule:
             self.setSwerveAngleTarget(optimizedAngle)
 
 
-# pylint: disable=abstract-method
+# pylint: disable-next=abstract-method
 class PWMSwerveModule(SwerveModule):
     """
     Implementation of SwerveModule designed for ease of simulation:
@@ -469,8 +469,8 @@ class DriveSubsystem(SubsystemBase):
         SmartDashboard.putBoolean(constants.kRobotPoseArrayKeys.validKey, True)
 
         if self.printTimer.hasPeriodPassed(constants.kPrintPeriod):
-            # pylint:disable=consider-using-f-string
             print(
+                # pylint:disable-next=consider-using-f-string
                 "r: {:.1f}, {:.1f}, {:.0f}* fl: {:.0f}* {:.1f} fr: {:.0f}* {:.1f} bl: {:.0f}* {:.1f} br: {:.0f}* {:.1f}".format(
                     robotPose.X(),
                     robotPose.Y(),


### PR DESCRIPTION
pylint disable doesn't do what you think it does, even though everyone on Google thinks it disables the next line....

disable is block scoped, so it disables that lint warning for the duration of the block or until it is reenabled.  disable-next disables the single next line which is a better use case for what we want.