### PR TITLE
Remove indirect requirements for simplicity

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ "windows-2019", "ubuntu-latest" ]
         python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
@@ -23,8 +24,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --no-deps -r requirements.txt
+          python -m pip install --upgrade pip wheel
+          pip install -r requirements.txt
       - name: Analysing the code with pylint
         run: |
           pylint $(git ls-files '*.py')

--- a/.github/workflows/sim-sanity-test.yml
+++ b/.github/workflows/sim-sanity-test.yml
@@ -20,8 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --no-deps -r requirements.txt
+          python -m pip install --upgrade pip wheel
+          pip install -r requirements.txt
       - name: Verify simulator starts up
         run: |
           ./scripts/verify-simulator-starts.sh

--- a/README.md
+++ b/README.md
@@ -103,10 +103,15 @@ py -3 -m venv ./.venv
      ```bash
      source <path-to-mentorbot-repo>/.venv/bin/activate
      ```
+1. **Update pip and wheel.  Old versions of pip can prevent binary wheels from being installed.  Installing wheel makes other installs faster**
+   (must have internet connection)
+   ```bash
+   python -m pip install --upgrade pip wheel
+   ```
 1. **Install / update robotpy**
    (must have internet connection)
    ```bash
-   python -m pip install --no-deps -r requirements.txt
+   python -m pip install -r requirements.txt
    ```
    (examples: `robotpy`, `robotpy[ctre,navx]`, `robotpy[all]`) (see: [robotpy on pypi](https://pypi.org/project/robotpy/))
 1. **Download python for roboRIO**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,8 @@
-# Non RobotPy packages, some are required by RobotPy because for simplicity we don't pin them,
-# just explicitly list that they are required
-attrs
-astroid
-bcrypt
-cffi
-click
-cryptography
-lazy-object-proxy
-iniconfig
-isort
-mccabe
-pluggy
-packaging
-paramiko
-pint
-platformdirs
-py
-pycparser
-pynacl
-pyparsing
-pyyaml
+# Non RobotPy packages that we use
+black
 pylint
 pytest
-six
-toml
-typing-extensions
 wheel
-wrapt
 # RobotPy packages.  We explicitly list the version number on all these packages so that when RobotPy
 # updates we don't break the world until we have a chance to test/update.
 pyfrc==2022.0.2


### PR DESCRIPTION
I got a little aggressive with the requirements pinning, it was causing different dependency issues on different platforms.  We pin the robotpy requirements, that is really enough for our use case.