### PR TITLE
Feature/fix pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -92,7 +92,8 @@ disable=raw-checker-failed,
         missing-class-docstring,
         line-too-long,
         duplicate-code,
-        no-else-return
+        no-else-return,
+        unnecessary-lambda-assignment
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/commands/climber/moveclimberstofullhangingposition.py
+++ b/commands/climber/moveclimberstofullhangingposition.py
@@ -14,7 +14,6 @@ class LeftClimberPivotVertical(CommandBase):
     def initialize(self) -> None:
         self.climber.leftClimber.retractPiston()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True
 
@@ -36,7 +35,6 @@ class RetractLeftClimberToFullHangingPosition(CommandBase):
         self.climber.leftClimber.climberMotor.neutralOutput()
         self.climber.leftClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(
@@ -59,7 +57,6 @@ class RightClimberPivotVertical(CommandBase):
     def initialize(self) -> None:
         self.climber.rightClimber.retractPiston()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True
 
@@ -81,7 +78,6 @@ class RetractRightClimberToFullHangingPosition(CommandBase):
         self.climber.rightClimber.climberMotor.neutralOutput()
         self.climber.rightClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(

--- a/commands/climber/moveclimberstomiddlerungcaptureposition.py
+++ b/commands/climber/moveclimberstomiddlerungcaptureposition.py
@@ -25,7 +25,6 @@ class MoveLeftClimberToMiddleRungCapturePosition(CommandBase):
         self.climber.leftClimber.climberMotor.neutralOutput()
         self.climber.leftClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(
@@ -56,7 +55,6 @@ class MoveRightClimberToMiddleRungCapturePosition(CommandBase):
         self.climber.rightClimber.climberMotor.neutralOutput()
         self.climber.rightClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(

--- a/commands/climber/moveclimberstomiddlerunghangposition.py
+++ b/commands/climber/moveclimberstomiddlerunghangposition.py
@@ -22,7 +22,6 @@ class MoveLeftClimberToMiddleRungHangPosition(CommandBase):
         self.climber.leftClimber.climberMotor.neutralOutput()
         self.climber.leftClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(
@@ -53,7 +52,6 @@ class MoveRightClimberToMiddleRungHangPosition(CommandBase):
         self.climber.rightClimber.climberMotor.neutralOutput()
         self.climber.rightClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(

--- a/commands/climber/moveclimberstonextrungcaptureposition.py
+++ b/commands/climber/moveclimberstonextrungcaptureposition.py
@@ -22,7 +22,6 @@ class MoveLeftClimberToNextRungCapturePosition(CommandBase):
         self.climber.leftClimber.climberMotor.neutralOutput()
         self.climber.leftClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(
@@ -53,7 +52,6 @@ class MoveRightClimberToNextRungCapturePosition(CommandBase):
         self.climber.rightClimber.climberMotor.neutralOutput()
         self.climber.rightClimber.activateBrake()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return (
             abs(

--- a/commands/climber/pivotclimbersformid.py
+++ b/commands/climber/pivotclimbersformid.py
@@ -16,7 +16,6 @@ class PivotLeftClimberToVertical(CommandBase):
     def execute(self) -> None:
         self.climber.leftClimber.retractPiston()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True
 
@@ -31,7 +30,6 @@ class PivotRightClimberToVertical(CommandBase):
     def execute(self) -> None:
         self.climber.rightClimber.retractPiston()
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True
 

--- a/commands/defensestate.py
+++ b/commands/defensestate.py
@@ -24,6 +24,5 @@ class DefenseState(CommandBase):
         setModuleTo(self.drive.backLeftModule, Rotation2d.fromDegrees(135))
         setModuleTo(self.drive.backRightModule, Rotation2d.fromDegrees(-135))
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")

--- a/commands/indexer/feedforward.py
+++ b/commands/indexer/feedforward.py
@@ -15,10 +15,8 @@ class FeedForward(CommandBase):
     def execute(self) -> None:
         self.indexer.feedBallForward()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/indexer/holdball.py
+++ b/commands/indexer/holdball.py
@@ -15,10 +15,8 @@ class HoldBall(CommandBase):
     def execute(self) -> None:
         self.indexer.holdBall()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/indexer/reverseindexer.py
+++ b/commands/indexer/reverseindexer.py
@@ -15,10 +15,8 @@ class ReverseIndexer(CommandBase):
     def execute(self) -> None:
         self.indexer.reversePath()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/indexer/stopindexer.py
+++ b/commands/indexer/stopindexer.py
@@ -15,10 +15,8 @@ class StopIndexer(CommandBase):
     def execute(self) -> None:
         self.indexer.motorsOff()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/intake/deployintake.py
+++ b/commands/intake/deployintake.py
@@ -16,10 +16,8 @@ class DeployIntake(CommandBase):
     def execute(self) -> None:
         self.intake.deployIntake()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/intake/retractintake.py
+++ b/commands/intake/retractintake.py
@@ -16,10 +16,8 @@ class RetractIntake(CommandBase):
     def execute(self) -> None:
         self.intake.retractIntake()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/intake/reverseintake.py
+++ b/commands/intake/reverseintake.py
@@ -16,10 +16,8 @@ class ReverseIntake(CommandBase):
     def execute(self) -> None:
         self.intake.reverseIntake()
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/resetdrive.py
+++ b/commands/resetdrive.py
@@ -19,10 +19,8 @@ class ResetDrive(CommandBase):
         self.drive.resetSwerveModules()
         self.drive.setOdometryPosition(self.position)
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/resetgyro.py
+++ b/commands/resetgyro.py
@@ -18,10 +18,8 @@ class ResetGyro(CommandBase):
     def execute(self) -> None:
         self.drive.resetGyro(self.position)
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/shooter/decreaseshooterspeed.py
+++ b/commands/shooter/decreaseshooterspeed.py
@@ -18,10 +18,8 @@ class DecreaseShooterSpeed(CommandBase):
             constants.kWheelSpeedTweakKey, num - constants.kWheelSpeedTweakAmount
         )
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/shooter/increaseshooterspeed.py
+++ b/commands/shooter/increaseshooterspeed.py
@@ -18,10 +18,8 @@ class IncreaseShooterSpeed(CommandBase):
             constants.kWheelSpeedTweakKey, num + constants.kWheelSpeedTweakAmount
         )
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/shooter/resetshooteroffset.py
+++ b/commands/shooter/resetshooteroffset.py
@@ -15,10 +15,8 @@ class ResetShooterOffset(CommandBase):
     def execute(self) -> None:
         SmartDashboard.putNumber(constants.kWheelSpeedTweakKey, 0)
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/shooter/resetshooting.py
+++ b/commands/shooter/resetshooting.py
@@ -18,10 +18,8 @@ class ResetShooting(CommandBase):
         self.shooter.setAsStartingPosition()
         self.shooter.rotateTurret(Rotation2d.fromDegrees(0))
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/commands/shooter/stopaimsystem.py
+++ b/commands/shooter/stopaimsystem.py
@@ -24,6 +24,5 @@ class StopMovingParts(ParallelCommandGroup):
         super().__init__(StopIndexer(indexer), StopAimSystem(shooter))
         self.setName(__class__.__name__)
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return False

--- a/commands/shooter/tarmacshot.py
+++ b/commands/shooter/tarmacshot.py
@@ -20,10 +20,8 @@ class TarmacShot(CommandBase):
         self.shooter.setHoodAngle(constants.kTarmacHoodAngle)
         self.shooter.setWheelSpeed(constants.kTarmacWheelSpeed)
 
-    # pylint: disable-next=no-self-use
     def end(self, _interrupted: bool) -> None:
         print("... DONE")
 
-    # pylint: disable-next=no-self-use
     def isFinished(self) -> bool:
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Non RobotPy packages that we use
 black
-pylint
+pylint==2.14.5
 pytest
 wheel
 # RobotPy packages.  We explicitly list the version number on all these packages so that when RobotPy

--- a/robot.py
+++ b/robot.py
@@ -58,7 +58,6 @@ class MentorBot(commands2.TimedCommandRobot):
     def teleopPeriodic(self) -> None:
         """This function is called periodically during operator control"""
 
-    # pylint: disable-next=no-self-use
     def testInit(self) -> None:
         # Cancels all running commands at the start of test mode
         commands2.CommandScheduler.getInstance().cancelAll()

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -69,8 +69,6 @@ from operatorinterface import OperatorInterface
 from util.helpfultriggerwrappers import AxisButton, SmartDashboardButton
 
 
-
-
 class RobotContainer:
     """
     This class is where the bulk of the robot should be declared. Since Command-based is a

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -48,14 +48,14 @@ from commands.intake.retractintake import RetractIntake
 from commands.shooter.aimshootertotarget import AimShooterToTarget
 from commands.shooter.aimshootermanual import AimShooterManually
 from commands.shooter.stopaimsystem import StopMovingParts
+from commands.shooter.decreaseshooterspeed import DecreaseShooterSpeed
+from commands.shooter.increaseshooterspeed import IncreaseShooterSpeed
+from commands.shooter.resetshooteroffset import ResetShooterOffset
 
 from commands.auto.fivebrstandard import FiveBRStandard
 from commands.auto.fourblnoninvasive import FourBLNoninvasive
 from commands.auto.twoblhangerouttake import TwoBLHangerOuttake
 from commands.auto.threebrstandard import ThreeBRStandard
-from commands.shooter.decreaseshooterspeed import DecreaseShooterSpeed
-from commands.shooter.increaseshooterspeed import IncreaseShooterSpeed
-from commands.shooter.resetshooteroffset import ResetShooterOffset
 
 from subsystems.drivesubsystem import DriveSubsystem
 from subsystems.visionsubsystem import VisionSubsystem

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -10,6 +10,7 @@ import constants
 from commands.resetdrive import ResetDrive
 from commands.complexauto import ComplexAuto
 from commands.indexer.feedforward import FeedForward
+from commands.indexer.holdball import HoldBall
 from commands.drivedistance import DriveDistance
 from commands.drivetotarget import DriveToTarget
 from commands.targetrelativedrive import TargetRelativeDrive
@@ -41,19 +42,20 @@ from commands.normalballpath import NormalBallPath
 from commands.shootball import ShootBall
 from commands.defensestate import DefenseState
 
-from commands.indexer.holdball import HoldBall
 from commands.intake.autoballintake import AutoBallIntake
 from commands.intake.deployintake import DeployIntake
 from commands.intake.retractintake import RetractIntake
 from commands.shooter.aimshootertotarget import AimShooterToTarget
 from commands.shooter.aimshootermanual import AimShooterManually
-from commands.shooter.tarmacshot import TarmacShot
 from commands.shooter.stopaimsystem import StopMovingParts
 
 from commands.auto.fivebrstandard import FiveBRStandard
 from commands.auto.fourblnoninvasive import FourBLNoninvasive
 from commands.auto.twoblhangerouttake import TwoBLHangerOuttake
 from commands.auto.threebrstandard import ThreeBRStandard
+from commands.shooter.decreaseshooterspeed import DecreaseShooterSpeed
+from commands.shooter.increaseshooterspeed import IncreaseShooterSpeed
+from commands.shooter.resetshooteroffset import ResetShooterOffset
 
 from subsystems.drivesubsystem import DriveSubsystem
 from subsystems.visionsubsystem import VisionSubsystem
@@ -66,9 +68,7 @@ from subsystems.shootersubsystem import ShooterSubsystem
 from operatorinterface import OperatorInterface
 from util.helpfultriggerwrappers import AxisButton, SmartDashboardButton
 
-from commands.shooter.decreaseshooterspeed import DecreaseShooterSpeed
-from commands.shooter.increaseshooterspeed import IncreaseShooterSpeed
-from commands.shooter.resetshooteroffset import ResetShooterOffset
+
 
 
 class RobotContainer:


### PR DESCRIPTION
Fix pylint to 2.14.5.  It appears that out of the box pylint has some issues with python 3.10.*.  So easiest thing for now is version lock it.  Once it gets addressed upstream renovatebot will figure it out and we can advance.

Fix some other pylint changes in the behavior of the checks that were causing breakages.