### PR TITLE
acceleration limit done via current limiting

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -24,6 +24,7 @@ Swerve Module Layout:
 """
 
 import math
+from ctre import SupplyCurrentLimitConfiguration
 from wpimath.geometry import Pose2d, Rotation2d, Translation2d
 from wpimath.system.plant import DCMotor
 
@@ -241,6 +242,10 @@ kStagingMotorPIDSlot = 0
 kStagingMotorPGain = 0.1
 kStagingMotorIGain = 0
 kStagingMotorDGain = 0
+
+kDriveSupplyCurrentLimitConfiguration = SupplyCurrentLimitConfiguration(
+    enable=True, currentLimit=35, triggerThresholdCurrent=60, triggerThresholdTime=0.1
+)
 
 # Encoders
 kFrontLeftSteerEncoderId = 40


### PR DESCRIPTION
inspired by 1678's implementation, the end goal of acceleration limiting is simply to reduce the current draw on motors, so this implementation puts a [Supply Current Limit](https://robotpy.readthedocs.io/projects/ctre/en/stable/ctre/SupplyCurrentLimitConfiguration.html) onto each drive motor