### PR TITLE
only turn on limelight LEDs when a ball is present in the system

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -206,6 +206,7 @@ kLimelightNetworkTableName = "limelight"
 kLimelightTargetValidKey = "tv"
 kLimelightTargetHorizontalAngleKey = "tx"
 kLimelightTargetVerticalAngleKey = "ty"
+kLimelightLEDModeKey = "ledMode"
 
 
 # Limelight (cargo)

--- a/subsystems/visionsubsystem.py
+++ b/subsystems/visionsubsystem.py
@@ -143,6 +143,12 @@ class LimelightTrackingModule(TrackingModule):
     def getTargetFacingAngle(self) -> typing.Optional[Rotation2d]:
         return self.targetFacingAngle
 
+    def setLEDS(self, on: bool) -> None:
+        self.limelightNetworkTable.putNumber(
+            constants.kLimelightLEDModeKey, 3 if on else 1
+        )
+        # https://docs.limelightvision.io/en/latest/networktables_api.html#camera-controls
+
     def update(self) -> None:
         targetValid = self.limelightNetworkTable.getNumber(
             constants.kLimelightTargetValidKey, constants.kLimelightTargetInvalidValue
@@ -193,6 +199,11 @@ class VisionSubsystem(SubsystemBase):
         Called periodically by the command framework. Updates the estimate of the target's pose from the tracking data.
         """
         self.updateTimer += constants.kRobotUpdatePeriod
+
+        if SmartDashboard.getBoolean(constants.kReadyToFireKey, False):
+            self.trackingModule.setLEDS(True)
+        else:
+            self.trackingModule.setLEDS(False)
 
         if self.updateTimer >= constants.kLimelightUpdatePeriod:
             self.updateTimer = 0


### PR DESCRIPTION
https://youtu.be/-vA16qdfVKE?t=94 as seen in this clip, there are instances in which an unexpected interference from the limelight does cause the bot odometry to shift (notably when the limelight is facing the hangar truss)

by turning off the lights when not needed, we prevent the chance of this happening again and a corrective measure such as whipping the turret around has to be employed