### PR TITLE
always use only odometry data in shooter

### DIFF
--- a/commands/shooter/aimshootertotarget.py
+++ b/commands/shooter/aimshootertotarget.py
@@ -20,37 +20,26 @@ class AimShooterToTarget(CommandBase):
         if SmartDashboard.getBoolean(
             constants.kReadyToFireKey, False
         ):  # only start tracking when ready to fire
-            distance = SmartDashboard.getNumber(
-                constants.kTargetDistanceRelativeToRobotKeys.valueKey, 0
+            currentPose = Pose2d(
+                *SmartDashboard.getNumberArray(
+                    constants.kRobotPoseArrayKeys.valueKey, [0, 0, 0]
+                )
             )
+
+            staticDifference = Transform2d(
+                currentPose, constants.kSimDefaultTargetLocation
+            )
+            staticRotation = rotationFromTranslation(staticDifference.translation())
+
+            self.shooter.rotateTurret(
+                optimizeAngle(constants.kTurretRelativeForwardAngle, staticRotation)
+                + constants.kTurretOffsetFromRobotAngle
+            )
+
+            distance = staticDifference.translation().norm()
             hoodAngle = constants.kHoodMappingFunction(distance)
             wheelSpeed = constants.kShootingMappingFunction(
                 distance
             ) + SmartDashboard.getNumber(constants.kWheelSpeedTweakKey, 0)
             self.shooter.setHoodAngle(Rotation2d.fromDegrees(hoodAngle))
             self.shooter.setWheelSpeed(wheelSpeed)
-
-            if SmartDashboard.getBoolean(
-                constants.kTargetAngleRelativeToRobotKeys.validKey, False
-            ):  # if we have an angle, use the relative angle to adjust the turret for precision
-                angle = SmartDashboard.getNumber(
-                    constants.kTargetAngleRelativeToRobotKeys.valueKey, 0.0
-                )
-
-                self.shooter.trackTurret(angle)  # always track the turret
-            else:  # ...otherwise use odometry to estimate where the target SHOULD be
-                currentPose = Pose2d(
-                    *SmartDashboard.getNumberArray(
-                        constants.kRobotPoseArrayKeys.valueKey, [0, 0, 0]
-                    )
-                )
-
-                staticDifference = Transform2d(
-                    currentPose, constants.kSimDefaultTargetLocation
-                )
-                staticRotation = rotationFromTranslation(staticDifference.translation())
-
-                self.shooter.rotateTurret(
-                    optimizeAngle(constants.kTurretRelativeForwardAngle, staticRotation)
-                    + constants.kTurretOffsetFromRobotAngle
-                )


### PR DESCRIPTION
we already use the vision system to backfeed into our odometry, and it has smoothing out from potential noise that exists within vision

we already have proven that odometry only has worked for our shooter system, and so using only odometry has more benefits than drawbacks.

This also decreases our time from stop to scoring, as the shooter is actively lining itself up on a shot as we go towards the hub with limited vision data